### PR TITLE
Switched dhcp from udhcpd to dnsmasq

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -8,6 +8,6 @@ Standards-Version: 3.9.4
 Package: spaceify
 Architecture: all
 Pre-Depends: debconf (>= 0.5)
-Depends: debconf (>= 0.5), libc6 (>= 2.1), ${misc:Depends}, perl, python-software-properties, python, g++, make, nodejs (>= 0.10.18), npm, libkrb5-dev, docker-engine | docker-hypriot, hostapd, curl, openssl, libssl-dev, sqlite3, libsqlite3-dev, libzip-dev, zip, unzip, git, udhcpd, dnsmasq | network-manager 
+Depends: debconf (>= 0.5), libc6 (>= 2.1), ${misc:Depends}, perl, python-software-properties, python, g++, make, nodejs (>= 0.10.18), npm, libkrb5-dev, docker-engine | docker-hypriot, hostapd, curl, openssl, libssl-dev, sqlite3, libsqlite3-dev, libzip-dev, zip, unzip, git, dnsmasq | network-manager 
 Description: Spaceify is a smart access point platform.
  This package will turn your computer into a Spaceify edge node and installs Spaceify's servers on your computer.

--- a/debian/postinst
+++ b/debian/postinst
@@ -185,7 +185,7 @@ core_port=$(echo $core_port | awk -F ' ' '{print $1}')
 
 ################## DNS CONFIGURATION #########################################
 
-dnsmasqconf="listen-address=127.0.0.1,10.0.0.1 \naddress=/edge.spaceify.net/10.0.0.1\n"
+dnsmasqconf="listen-address=127.0.0.1,10.0.0.1 \naddress=/edge.spaceify.net/10.0.0.1\ndhcp-range=10.0.0.2,10.0.0.254,4h\ndhcp-option=3,10.0.0.1\ndhcp-option=6,10.0.0.1\ndhcp-option=15,edge.spaceify.net\ndhcp-authoritative"
 
 #If NetworkManager is installed, configure the dnsmasq that shipped with it
 
@@ -201,24 +201,24 @@ fi
 
 # ----- /etc/udhcpd.conf, /etc/default/udhcpd ----- #
 
-mv /etc/udhcpd.conf /etc/udhcpd.conf.original > /dev/null 2>&1 || true						# store existing configuration
-mv /etc/default/udhcpd /etc/default/udhcpd.original > /dev/null 2>&1 || true
+#mv /etc/udhcpd.conf /etc/udhcpd.conf.original > /dev/null 2>&1 || true						# store existing configuration
+#mv /etc/default/udhcpd /etc/default/udhcpd.original > /dev/null 2>&1 || true
 
-dhcpd="start 10.0.0.2\n"
-dhcpd="${dhcpd}end 10.0.0.254\n"
-dhcpd="${dhcpd}interface ${wlan}\n"
-dhcpd="${dhcpd}opt dns 10.0.0.1 10.0.0.1\n"
-dhcpd="${dhcpd}option dns 10.0.0.1\n"
-dhcpd="${dhcpd}opt router 10.0.0.1\n"
-dhcpd="${dhcpd}option subnet 255.255.255.0\n"
-dhcpd="${dhcpd}option lease 7200\n"
-dhcpd="${dhcpd}option domain spaceify.net\n"
-dhcpd="${dhcpd}opt broadcast 10.0.0.255\n\n"
-printf "$dhcpd" > /etc/udhcpd.conf
+#dhcpd="start 10.0.0.2\n"
+#dhcpd="${dhcpd}end 10.0.0.254\n"
+#dhcpd="${dhcpd}interface ${wlan}\n"
+#dhcpd="${dhcpd}opt dns 10.0.0.1 10.0.0.1\n"
+#dhcpd="${dhcpd}option dns 10.0.0.1\n"
+#dhcpd="${dhcpd}opt router 10.0.0.1\n"
+#dhcpd="${dhcpd}option subnet 255.255.255.0\n"
+#dhcpd="${dhcpd}option lease 7200\n"
+#dhcpd="${dhcpd}option domain spaceify.net\n"
+#dhcpd="${dhcpd}opt broadcast 10.0.0.255\n\n"
+#printf "$dhcpd" > /etc/udhcpd.conf
 
-dhcpd="DHCPD_ENABLED=\"yes\"\n"
-dhcpd="${dhcpd}DHCPD_OPTS=\"-S\"\n\n"
-printf "$dhcpd" > /etc/default/udhcpd
+#dhcpd="DHCPD_ENABLED=\"yes\"\n"
+#dhcpd="${dhcpd}DHCPD_OPTS=\"-S\"\n\n"
+#printf "$dhcpd" > /etc/default/udhcpd
 
 	# ----- /etc/init/spaceify.conf, /etc/init/spaceifydns.conf, /etc/init/spaceifyipt.conf ----- #
 #cp /var/lib/spaceify/data/upstart/* /etc/init/ > /dev/null 2>&1 || true						# Copy upstart scripts to /etc/init/
@@ -395,8 +395,8 @@ cp /var/lib/spaceify/data/scripts/spaceifyCA/spaceify.crt /var/lib/spaceify/code
 
 	# ----- File permissions etc. ----- #
 
-mkdir -p /var/lib/spaceify/data/dhcp-data > /dev/null 2>&1 || true							# dhcp server directories/files
-chmod -R 0664 /var/lib/spaceify/data/dhcp-data > /dev/null 2>&1 || true
+#mkdir -p /var/lib/spaceify/data/dhcp-data > /dev/null 2>&1 || true					# dhcp server directories/files
+#chmod -R 0664 /var/lib/spaceify/data/dhcp-data > /dev/null 2>&1 || true
 # chown - R root:spaceify /var/lib/spaceify/data/dhcp-data > /dev/null 2>&1 || true
 
 mkdir -p /var/lib/spaceify/data/ipt-data > /dev/null 2>&1 || true							# iptables directories/files


### PR DESCRIPTION
DnsMasq is now used as the DHCP server instead of udhcpd. Raspberry Pi can now act as an Edge Node with an internal WiFi access point.
