### PR TITLE
TG-61-edge-name-errors-on-install

### DIFF
--- a/build-package.sh
+++ b/build-package.sh
@@ -58,7 +58,7 @@ cp -r data/minify/ "$dst/data"
 # ---------- UGLIFYING/MINIFYING  FILES ---------- #
 
 node "$dst/data/minify/minify.js" $dst
-gme=$?
+uglifyMinifyError=$?
 
 # ----------
 # ----------
@@ -88,9 +88,12 @@ cd $dst
 
 chown -R root:root debian/
 dpkg-buildpackage -i.svn -us -uc
+dpkgBuildpackageError=$?
 
-if [ $? == 0 ] && [ $gme == 0 ]; then
+if [ $dpkgBuildpackageError == 0 ] && [ $uglifyMinifyError == 0 ]; then
 	printf "\n\e[42mPackage build. Files are in directory $dstBase\e[0m\n\n"
 else
-	printf "\n\e[41mBuilding package failed\e[0m\n\n"
+	printf "\n\e[101mBuilding package failed: uglifyMinifyError=$uglifyMinifyError, dpkgBuildpackageError=$dpkgBuildpackageError\e[0m\n\n"
+
+	rm -r /tmp/build/ > /dev/null 2>&1 || true
 fi

--- a/code/www/libs/spaceifyconfig.js
+++ b/code/www/libs/spaceifyconfig.js
@@ -12,7 +12,7 @@ var self = this;
 
 if(typeof exports !== "undefined")
 	{
-	var i, file = require("fs").readFileSync((process.env.IS_REAL_SPACEIFY ? "/api/www/libs/" : "www/libs/") + "config.json", "utf8");
+	var i, file = require("fs").readFileSync((process.env.IS_REAL_SPACEIFY ? "/api/www/libs/" : "/var/lib/spaceify/code/www/libs/") + "config.json", "utf8");
 
 	var config = JSON.parse(file);
 	for(i in config)

--- a/data/scripts/database.sh
+++ b/data/scripts/database.sh
@@ -35,7 +35,7 @@ release_name=$(echo $edge | awk -F , '{print $2}')
 db_version=$(echo $versions | awk -F : '{print $6}')
 
 current_version=$(sqlite3 $dbs "SELECT db_version FROM information;" || false)
-if [ $? -ne 0 ]; then																	# Settings contains version if information table doesn't exist yet
+if [[ $? != 0 ]]; then																	# Settings contains version if information table doesn't exist yet
 	current_version=$(sqlite3 $dbs "SELECT db_version FROM settings;" || false)
 fi
 
@@ -51,13 +51,13 @@ rm /var/lib/spaceify/data/db/admin_password > /dev/null 2>&1 || true
 # ----------
 # ---------- Changes between database versions ---------- #
 
-if [ $current_version -lt 6 ]; then
+if (( $current_version < 6 )); then
 
 	sqlite3 $dbs "ALTER TABLE applications ADD COLUMN position INTEGER DEFAULT 0;"
 
 fi
 
-if [ $current_version -le 7 ]; then
+if (( $current_version <= 7 )); then
 
 	IFS=";" read -a tables <<< $(< $dbc)
 
@@ -100,7 +100,7 @@ if [ $current_version -le 7 ]; then
 
 fi
 
-if [ $current_version -lt 8 ]; then
+if (( $current_version < 8 )); then
 
 	sqlite3 $dbs "ALTER TABLE information ADD COLUMN distribution TEXT;"
 

--- a/data/scripts/database.sh
+++ b/data/scripts/database.sh
@@ -35,7 +35,7 @@ release_name=$(echo $edge | awk -F , '{print $2}')
 db_version=$(echo $versions | awk -F : '{print $6}')
 
 current_version=$(sqlite3 $dbs "SELECT db_version FROM information;" || false)
-if [[ $? != 0 ]]; then																	# Settings contains version if information table doesn't exist yet
+if [ $? -ne 0 ]; then																	# Settings contains version if information table doesn't exist yet
 	current_version=$(sqlite3 $dbs "SELECT db_version FROM settings;" || false)
 fi
 
@@ -51,13 +51,13 @@ rm /var/lib/spaceify/data/db/admin_password > /dev/null 2>&1 || true
 # ----------
 # ---------- Changes between database versions ---------- #
 
-if [[ $current_version < 6 ]]; then
+if [ $current_version -lt 6 ]; then
 
 	sqlite3 $dbs "ALTER TABLE applications ADD COLUMN position INTEGER DEFAULT 0;"
 
 fi
 
-if [[ $current_version <= 7 ]]; then
+if [ $current_version -le 7 ]; then
 
 	IFS=";" read -a tables <<< $(< $dbc)
 
@@ -100,7 +100,7 @@ if [[ $current_version <= 7 ]]; then
 
 fi
 
-if [[ $current_version < 8 ]]; then
+if [ $current_version -lt 8 ]; then
 
 	sqlite3 $dbs "ALTER TABLE information ADD COLUMN distribution TEXT;"
 

--- a/debian/config
+++ b/debian/config
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash
 
 # Source debconf library
 . /usr/share/debconf/confmodule
@@ -13,8 +13,8 @@ db_subst spaceify/ethernet ADAPTERS "$ADAPTERS"										# replace names in debc
 db_subst spaceify/wlan ADAPTERS "$ADAPTERS"
 
 # Get existing edge name
-if [ -e /tmp/edge_id.uuid ]; then mv /tmp/edge_id.uuid  /tmp/edge.id; fi			# edge_id.uuid -> edge.id
-if [ -e /var/lib/spaceify/data/db/edge_id.uuid ]; then mv /var/lib/spaceify/data/db/edge_id.uuid  /var/lib/spaceify/data/db/edge.id; fi
+if [ -e /tmp/edge_id.uuid ]; then mv /tmp/edge_id.uuid /tmp/edge.id; fi				# edge_id.uuid -> edge.id
+if [ -e /var/lib/spaceify/data/db/edge_id.uuid ]; then mv /var/lib/spaceify/data/db/edge_id.uuid /var/lib/spaceify/data/db/edge.id; fi
 
 if [ -e /tmp/edge.id ]; then
 	edge_name=$(echo $(< /tmp/edge.id) | awk -F ',' '{print $2}')
@@ -63,34 +63,51 @@ do
 	6)
 		db_input critical spaceify/admin_password || true
 		db_input critical spaceify/admin_confirm_password || true
-		if db_go; then dbStatus=0; else dbStatus=30; fi
 
-		db_get spaceify/admin_password
-		admin_password="$RET"
+		if db_go; then
 
-		db_get spaceify/admin_confirm_password
-		admin_confirm_password="$RET"
-
-		if [ "$admin_password" != "$admin_confirm_password" ]; then
-			STATE=0
 			dbStatus=0
-			db_reset spaceify/admin_password
-			db_reset spaceify/admin_confirm_password
+			
+			db_get spaceify/admin_password
+			admin_password="$RET"
+
+			db_get spaceify/admin_confirm_password
+			admin_confirm_password="$RET"
+
+			if [ "$admin_password" != "$admin_confirm_password" ]; then
+				STATE=0
+				db_reset spaceify/admin_password
+				db_reset spaceify/admin_confirm_password
+			fi
+			
+		else
+
+			dbStatus=30
+
 		fi
+
 	;;
 
 	7)
 		db_input critical spaceify/edge_name || true
-		if db_go; then dbStatus=0; else dbStatus=30; fi
 
-		db_get spaceify/edge_name
-		edge_name="$RET"
+		if db_go; then
 
-		if [[ ! $edge_name =~ ^[a-zA-Z0-9]{4,32}$ ]]; then
-			STATE=1
 			dbStatus=0
-			db_set spaceify/edge_name $edge_name
+			
+			db_get spaceify/edge_name
+			edge_name="$RET"
+
+			if [[ ! $edge_name =~ ^[a-zA-Z0-9]{4,32}$ ]]; then
+				STATE=1
+			fi
+
+		else
+
+			dbStatus=30
+
 		fi
+
 	;;
 	esac
 
@@ -103,6 +120,5 @@ do
 		if [[ $STATE -le 2 ]]; then
 			STATE=3
 		fi
-
 	fi
 done

--- a/debian/postinst
+++ b/debian/postinst
@@ -357,7 +357,7 @@ fi
 
 hasImage=$( echo $(docker images) | sed -n "/$distro_image_name/{p;q;}" )
 if [ -z "$hasImage" ]; then
-	printf "\n\e[41mThe installation is aborted because the required $distro_image_name Docker image doesn't exist. Run 'apt-get purge spaceify' to remove the incomplete installation. NOTICE: Save files that you want to preserve before removing the installation.\e[0m\n\n"
+	printf "\n\e[101mThe installation is aborted because the required $distro_image_name Docker image doesn't exist. Run 'apt-get purge spaceify' to remove the incomplete installation. NOTICE: Save files that you want to preserve before removing the installation.\e[0m\n\n"
 	exit 1
 else
 	printf $new_version > $if_version															# Update the version file
@@ -400,7 +400,7 @@ ifup ${wlan}
 . /var/lib/spaceify/data/scripts/wait_network.sh 0 300 50 "Please wait, restarting network."
 
 if [ $? -ne 0 ]; then
-       printf "\e[41mThe installation is aborted because restarting the network failed. Run 'apt-get purge spaceify' to remove the incomplete installation. "
+       printf "\e[101mThe installation is aborted because restarting the network failed. Run 'apt-get purge spaceify' to remove the incomplete installation. "
        exit 1
 else
        printf "The network is restarted. Continuing the installation.\n"


### PR DESCRIPTION
When installer runs debian/config script it outputs warnings regarding spaceify/edge_name. Running dpkg-reconfigure loops the edge name input phase forever even if the edge name is valid.
