### PR TITLE
TG-67 build-package.sh fails because of missing node command on fresh Ubuntu Server 16.04.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ There's an assumption that three network interfaces has been configured:
 
 * `NAT` for Internet access
 * Host-only `vbox0` for communication between host machine (192.168.56.1)
-* Host-only `vbox1` for communication to Spaceify users). (192.168.56.2)
+* Host-only `vbox1` for communication to Spaceify users). (192.168.57.1)
 
 For the network setup details in VirtualBox, see this [guide](https://spaceify.org/wiki/doku.php?id=tutorials:running_spaceify_in_virtualbox).
 

--- a/build-package.sh
+++ b/build-package.sh
@@ -56,8 +56,11 @@ cp -r data/minify/ "$dst/data"
 # ----------
 # ----------
 # ---------- UGLIFYING/MINIFYING  FILES ---------- #
-
-node "$dst/data/minify/minify.js" $dst
+nodecmd="node"
+if type nodejs >/dev/null 2>&1; then
+	nodecmd="nodejs"
+fi
+$nodecmd "$dst/data/minify/minify.js" $dst
 uglifyMinifyError=$?
 
 # ----------

--- a/data/scripts/install_spaceify_prerequisite.sh
+++ b/data/scripts/install_spaceify_prerequisite.sh
@@ -3,7 +3,7 @@ apt-get install apt-transport-https ca-certificates
 apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
 sh -c "echo deb https://apt.dockerproject.org/repo ubuntu-xenial main\ > /etc/apt/sources.list.d/docker.list"
 apt-get update
-apt-get install dpkg-dev debhelper dh-systemd
+apt-get install dpkg-dev debhelper dh-systemd nodejs
 apt-get purge lxc-docker
 apt-cache policy docker-engine
 apt-get install docker-engine


### PR DESCRIPTION
Pull request for resolving #10 .
